### PR TITLE
golang-google-cicd to 0.0.16

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.89
 - name: golang-google-cicd
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.12
+  version: 0.0.16
 - name: petclinic-jx
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.2


### PR DESCRIPTION
Promote golang-google-cicd to version 0.0.16